### PR TITLE
Add self-hosted aarch64 CI run on Raspberry Pi

### DIFF
--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -1,0 +1,19 @@
+name: Self-hosted build
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  ubuntu-aarch64-build:
+    runs-on:
+    - self-hosted
+    - rpi4
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: |
+        rm -rf build && mkdir build && cd build
+        cmake -GNinja ..
+        cmake --build . -j$(nproc)


### PR DESCRIPTION
Add CI for native build on ARM64 architecture on self-hosted runner